### PR TITLE
Change default quality to 1 per RFC 2616

### DIFF
--- a/src/LocalizationMiddleware.php
+++ b/src/LocalizationMiddleware.php
@@ -272,10 +272,11 @@ class LocalizationMiddleware
 
     protected function parseQuality(string $quality): float
     {
-        // If no quality is given then return 0.00001 as a sufficiently
-        // small value for sorting purposes.
+        // If no quality is given then return 1 as this is the default quality
+        // defined in RFC 2616 HTTP/1.1 section 14.4 Accept-Language
+        // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
         @list(, $value) = explode('=', $quality, 2);
-        return (float)($value ?: 0.0001);
+        return (float)($value ?: 1.0);
     }
 
     protected function sort(array $a, array $b): int

--- a/tests/LocalizationMiddlewareTest.php
+++ b/tests/LocalizationMiddlewareTest.php
@@ -43,7 +43,7 @@ class LocalizationMiddlewareTest extends TestCase
         $resp = self::createResponse();
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([LocalizationMiddleware::FROM_URI_PATH]);
-         
+
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
         $this->assertEquals('fr_CA', $req->getAttribute('locale'));
     }
@@ -136,7 +136,7 @@ class LocalizationMiddlewareTest extends TestCase
         $lmw->setCallback(function (string $locale) use (&$resolved) {
             $resolved = $locale;
         });
-         
+
         $lmw->__invoke($req, $resp, self::callable());
         $this->assertEquals('fr_CA', $resolved);
     }
@@ -164,7 +164,7 @@ class LocalizationMiddlewareTest extends TestCase
         $lmw->setSearchOrder([LocalizationMiddleware::FROM_HEADER]);
 
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
-        $this->assertEquals('es_MX', $req->getAttribute('locale'));
+        $this->assertEquals('fr_CA', $req->getAttribute('locale'));
     }
 
     public function testLocaleFromHeaderQualitySorted()
@@ -178,6 +178,19 @@ class LocalizationMiddlewareTest extends TestCase
 
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
         $this->assertEquals('es_MX', $req->getAttribute('locale'));
+    }
+
+    public function testLocaleFromHeaderQualitySortedDefault()
+    {
+        $req = self::createRequest([
+            'HTTP_ACCEPT_LANGUAGE' => 'en_US;q=0.2,fr_CA,es_MX;q=0.8'
+        ]);
+        $resp = self::createResponse();
+        $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
+        $lmw->setSearchOrder([LocalizationMiddleware::FROM_HEADER]);
+
+        list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
+        $this->assertEquals('fr_CA', $req->getAttribute('locale'));
     }
 
     public function testLocaleFromHeaderQualitySame()
@@ -201,7 +214,7 @@ class LocalizationMiddlewareTest extends TestCase
         $resp = self::createResponse();
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([LocalizationMiddleware::FROM_HEADER]);
-         
+
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
         $this->assertEquals('eo', $req->getAttribute('locale'));
     }
@@ -253,7 +266,7 @@ class LocalizationMiddlewareTest extends TestCase
             LocalizationMiddleware::FROM_HEADER,
             LocalizationMiddleware::FROM_URI_PARAM
         ]);
-         
+
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
         $this->assertEquals('es_MX', $req->getAttribute('locale'));
     }
@@ -264,7 +277,7 @@ class LocalizationMiddlewareTest extends TestCase
         $resp = self::createResponse();
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([999]);
-         
+
         $this->expectException('DomainException');
         $lmw->__invoke($req, $resp, self::callable());
     }


### PR DESCRIPTION
On Chrome on my box the Accept-Language header is `en-US,en;q=0.9,fr-CA;q=0.8,fr;q=0.7`. Per [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4) the default quality for `en-US` should be 1 instead of current 0.0001.

> Each language-range MAY be given an associated quality value which represents an estimate of the user's preference for the languages specified by that range. The quality value defaults to "q=1".

Using the example from the [README.md](https://github.com/tboronczyk/localization-middleware/blob/master/README.md) `$availableLocales = ['en_US', 'fr_CA', 'es_MX', 'eo'];` it returns `fr_CA` instead of `en_US`. With the provided modification it returns `en_US`.