### PR TITLE
Don't return user controlled locale string

### DIFF
--- a/src/LocalizationMiddleware.php
+++ b/src/LocalizationMiddleware.php
@@ -218,7 +218,7 @@ class LocalizationMiddleware
         // return the locale if it is available
         foreach ($this->availableLocales as $avail) {
             if ($locale == $avail['locale']) {
-                return $avail['locale'];
+                return $locale;
             }
         }
         return '';

--- a/src/LocalizationMiddleware.php
+++ b/src/LocalizationMiddleware.php
@@ -218,7 +218,7 @@ class LocalizationMiddleware
         // return the locale if it is available
         foreach ($this->availableLocales as $avail) {
             if ($locale == $avail['locale']) {
-                return $locale;
+                return $avail['locale'];
             }
         }
         return '';


### PR DESCRIPTION
In PHP "00" == "0000", the current code is safe but it's better to never return a potentialy dirty string.