### PR TITLE
Fix the case when header value with `*` causes Undefined offset: 0 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
   },
   "autoload": {
     "psr-4": { "Boronczyk\\": "src/" }
+  },
+  "autoload-dev": {
+    "psr-4": { "Boronczyk\\Tests\\": "tests/" }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit>
+<phpunit bootstrap="vendor/autoload.php">
  <testsuites>
   <testsuite name="Tests">
    <directory>tests</directory>

--- a/src/LocalizationMiddleware.php
+++ b/src/LocalizationMiddleware.php
@@ -272,7 +272,7 @@ class LocalizationMiddleware
         $values = [];
         foreach (explode(',', $header) as $lang) {
             @list($locale, $quality) = explode(';', $lang, 2);
-            $val = $this->parseLocale($locale);
+            $val = $this->parseLocale(str_replace('*', $this->defaultLocale, $locale));
             $val['quality'] = $this->parseQuality($quality ?? '');
             $values[] = $val;
         }

--- a/tests/LocalizationMiddlewareTest.php
+++ b/tests/LocalizationMiddlewareTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+namespace Boronczyk\Tests;
+
 error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
@@ -11,9 +13,6 @@ use Slim\Http\Environment;
 use Slim\Http\Request;
 use Slim\Http\Response;
 use Boronczyk\LocalizationMiddleware;
-
-chdir(dirname(__FILE__));
-require_once '../vendor/autoload.php';
 
 class LocalizationMiddlewareTest extends TestCase
 {
@@ -95,7 +94,7 @@ class LocalizationMiddlewareTest extends TestCase
         $req = self::createRequest([]);
         $resp = self::createResponse();
 
-        $ref = new ReflectionClass($req);
+        $ref = new \ReflectionClass($req);
         $prop = $ref->getProperty('cookies');
         $prop->setAccessible(true);
         $prop->setValue($req, ['locale' => 'fr_CA']);
@@ -128,7 +127,7 @@ class LocalizationMiddlewareTest extends TestCase
         $req = self::createRequest([]);
         $resp = self::createResponse();
 
-        $ref = new ReflectionClass($req);
+        $ref = new \ReflectionClass($req);
         $prop = $ref->getProperty('cookies');
         $prop->setAccessible(true);
         $prop->setValue($req, ['lang' => 'fr_CA']);
@@ -179,17 +178,28 @@ class LocalizationMiddlewareTest extends TestCase
         $this->assertEquals('fr_CA', $resolved);
     }
 
-    public function testLocaleFromHeader()
+    /**
+     * @dataProvider localeFromHeaderDataProvided
+     */
+    public function testLocaleFromHeader(string $header, string $expectedResult)
     {
         $req = self::createRequest([
-            'HTTP_ACCEPT_LANGUAGE' => 'fr_CA'
+            'HTTP_ACCEPT_LANGUAGE' => $header
         ]);
         $resp = self::createResponse();
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([LocalizationMiddleware::FROM_HEADER]);
 
         list($req, $resp) = $lmw->__invoke($req, $resp, self::callable());
-        $this->assertEquals('fr_CA', $req->getAttribute('locale'));
+        $this->assertEquals($expectedResult, $req->getAttribute('locale'));
+    }
+
+    public function localeFromHeaderDataProvided(): array
+    {
+        return [
+            ['fr_CA', 'fr_CA'],
+            ['en, *;q=0.7', self::$defaultLocale]
+        ];
     }
 
     public function testLocaleFromHeaderQuality()
@@ -266,7 +276,7 @@ class LocalizationMiddlewareTest extends TestCase
         ]);
         $resp = self::createResponse();
 
-        $ref = new ReflectionClass($req);
+        $ref = new \ReflectionClass($req);
         $prop = $ref->getProperty('cookies');
         $prop->setAccessible(true);
         $prop->setValue($req, ['locale' => 'pt_BR']);
@@ -330,7 +340,7 @@ class LocalizationMiddlewareTest extends TestCase
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([999]);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(\DomainException::class);
         $lmw->__invoke($req, $resp, self::callable());
     }
 
@@ -341,6 +351,6 @@ class LocalizationMiddlewareTest extends TestCase
         $lmw = new LocalizationMiddleware(self::$availableLocales, self::$defaultLocale);
         $lmw->setSearchOrder([LocalizationMiddleware::FROM_CALLBACK]);
 
-        $this->expectException(LogicException::class);
+        $this->expectException(\LogicException::class);
         $lmw->__invoke($req, $resp, self::callable());
     }}


### PR DESCRIPTION
I fased with the case when header value contains an asterisk sing `parseLocale` method fails
because of undefined index. ex.: `en, *;q=0.7`

I create a fix of the case be replacing `*` with default locale.

Additionally as side effect I adjusted phpunit configuration to get rid of `require_once` statement in test file if you don't mind.