### PR TITLE
Prevent overriding `Set-Cookie` header

### DIFF
--- a/src/LocalizationMiddleware.php
+++ b/src/LocalizationMiddleware.php
@@ -157,7 +157,7 @@ class LocalizationMiddleware
         $req = $req->withAttribute($this->reqAttrName, $locale);
 
         if (in_array(self::FROM_COOKIE, $this->searchOrder)) {
-            $resp = $resp->withHeader(
+            $resp = $resp->withAddedHeader(
                 'Set-Cookie',
                 "{$this->cookieName}=$locale; Path={$this->cookiePath}; Expires={$this->cookieExpire}"
             );


### PR DESCRIPTION
Use `MessageInterface::withAddedHeader()` instead of `MessageInterface::withHeader()`
in order to set localization cookies.

Issue tboronczyk/localization-middleware#16